### PR TITLE
Socket connection retry logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ In your hadoop-metrics2.properties file, add the following for all metrics
 	nodemanager.sink.graphite.servers=localhost:2003
 	resourcemanager.sink.graphite.servers=localhost:2003
 	secondarynamenode.sink.graphite.servers=localhost:2003
+
+	#Optional parameters for socket connection retry (Values below are default values for the same)
+	*.sink.graphite.retry_socket_interval=60000  #in milliseconds
+	*.sink.graphite.socket_connection_retries=10  #Set it to 0 if you do not want it to be retried
+	
+	

--- a/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
+++ b/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
@@ -69,6 +69,9 @@ public class GraphiteContext implements MetricsSink {
         hostname = "noHostnameListed";
       }
     }
+    
+    //To avoid domain name hierarchy to interfere with graphite metric hierarchy
+    hostname = hostname.replace('.', '-');
 
     StringBuilder sb = new StringBuilder();
     long tm = System.currentTimeMillis() / 1000;

--- a/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
+++ b/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
@@ -34,6 +34,7 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.SocketException;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -52,12 +53,18 @@ public class GraphiteContext implements MetricsSink {
   Socket socket;
 
   private static final int DEFAULT_PORT = 2003;
-
+  private static final int DEFAULT_RETRY_SOCKET_INTERVAL = 60000;
+  private static final int DEFAULT_SOCKET_CONNECTION_RETRIES = 10;
+  private int retrySocketInterval;
+  private int socketConnectionRetries;
 
   /* Configuration attribute names */
   protected static final String SERVER_NAME_PROPERTY = "servers";
+  private static final String RETRY_SOCKET_INTERVAL = "retry_socket_interval";
+  private static final String SOCKET_CONNECTION_RETRIES = "socket_connection_retries";
   public final Log LOG = LogFactory.getLog(this.getClass());
   Queue<String> metricsQueue = new LinkedBlockingDeque<String>();
+  private List<? extends SocketAddress> metricsServers;
 
   @Override
   public void putMetrics(MetricsRecord metricsRecord) {
@@ -69,7 +76,7 @@ public class GraphiteContext implements MetricsSink {
         hostname = "noHostnameListed";
       }
     }
-    
+
     //To avoid domain name hierarchy to interfere with graphite metric hierarchy
     hostname = hostname.replace('.', '-');
 
@@ -104,7 +111,9 @@ public class GraphiteContext implements MetricsSink {
       }
       writer.flush();
 
-    } catch (IOException e) {
+    } catch(SocketException e) {
+      establishConnection();
+    } catch (Exception e) {
       LOG.error(e);
     }
   }
@@ -112,18 +121,50 @@ public class GraphiteContext implements MetricsSink {
   @Override
   public void init(SubsetConfiguration conf) {
     LOG.info("Initializing the GraphiteSink");
-    List<? extends SocketAddress> metricsServers = Servers.parse(conf.getString(SERVER_NAME_PROPERTY),
+    metricsServers = Servers.parse(conf.getString(SERVER_NAME_PROPERTY),
         DEFAULT_PORT);
     for (SocketAddress metricServer: metricsServers){
       LOG.info("Adding metricServer" + metricServer);
     }
 
+    retrySocketInterval = conf.getInt(RETRY_SOCKET_INTERVAL, DEFAULT_RETRY_SOCKET_INTERVAL);
+    socketConnectionRetries = conf.getInt(SOCKET_CONNECTION_RETRIES,DEFAULT_SOCKET_CONNECTION_RETRIES);
+
+    socket = new Socket();
     try {
-      socket = new Socket();
       socket.connect(metricsServers.get(0));
-    } catch (IOException e) {
+    } catch(IOException e) {
       LOG.error(e);
     }
 
+  }
+
+  private void establishConnection() {
+
+    if (socket != null && !socket.isClosed()) {
+      try {
+        socket.close();
+      } catch (IOException e) {
+        LOG.error(e);
+      }
+    }
+
+    socket = new Socket();
+
+    int retryCount = 1;
+    while (!socket.isConnected() && retryCount <= socketConnectionRetries) {
+      try {
+        socket.connect(metricsServers.get(0));
+      } catch (IOException e) {
+        LOG.error(e);
+        LOG.debug("Retrying in:" + retrySocketInterval/1000 + "s");
+        try {
+          Thread.sleep(retrySocketInterval);
+        } catch (InterruptedException e1) {
+          LOG.error(e1);
+        }
+      }
+      retryCount++;
+    }
   }
 }

--- a/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
+++ b/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
@@ -65,6 +65,7 @@ public class GraphiteContext implements MetricsSink {
   public final Log LOG = LogFactory.getLog(this.getClass());
   Queue<String> metricsQueue = new LinkedBlockingDeque<String>();
   private List<? extends SocketAddress> metricsServers;
+  private boolean retryFlag = true;
 
   @Override
   public void putMetrics(MetricsRecord metricsRecord) {
@@ -150,6 +151,10 @@ public class GraphiteContext implements MetricsSink {
       }
     }
 
+    if (!retryFlag) {
+      return;
+    }
+
     socket = new Socket();
 
     int retryCount = 1;
@@ -163,6 +168,7 @@ public class GraphiteContext implements MetricsSink {
           Thread.sleep(retrySocketInterval);
           socket = new Socket();
         } catch (InterruptedException e1) {
+          retryFlag = false;
           LOG.error(e1);
         }
       }

--- a/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
+++ b/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
@@ -158,9 +158,10 @@ public class GraphiteContext implements MetricsSink {
         socket.connect(metricsServers.get(0));
       } catch (IOException e) {
         LOG.error(e);
-        LOG.debug("Retrying in:" + retrySocketInterval/1000 + "s");
+        LOG.info("Retrying in:" + retrySocketInterval/1000 + "s");
         try {
           Thread.sleep(retrySocketInterval);
+          socket = new Socket();
         } catch (InterruptedException e1) {
           LOG.error(e1);
         }

--- a/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
+++ b/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
@@ -139,6 +139,7 @@ public class GraphiteContext implements MetricsSink {
 
   }
 
+  // Retries the connection according to retry parameters obtained through conf
   private void establishConnection() {
 
     if (socket != null && !socket.isClosed()) {

--- a/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
+++ b/src/main/java/org/apache/hadoop/metrics2/graphite/GraphiteContext.java
@@ -128,7 +128,7 @@ public class GraphiteContext implements MetricsSink {
     }
 
     retrySocketInterval = conf.getInt(RETRY_SOCKET_INTERVAL, DEFAULT_RETRY_SOCKET_INTERVAL);
-    socketConnectionRetries = conf.getInt(SOCKET_CONNECTION_RETRIES,DEFAULT_SOCKET_CONNECTION_RETRIES);
+    socketConnectionRetries = conf.getInt(SOCKET_CONNECTION_RETRIES, DEFAULT_SOCKET_CONNECTION_RETRIES);
 
     socket = new Socket();
     try {
@@ -158,7 +158,7 @@ public class GraphiteContext implements MetricsSink {
         socket.connect(metricsServers.get(0));
       } catch (IOException e) {
         LOG.error(e);
-        LOG.info("Retrying in:" + retrySocketInterval/1000 + "s");
+        LOG.warn("Retrying in:" + retrySocketInterval/1000 + "s");
         try {
           Thread.sleep(retrySocketInterval);
           socket = new Socket();


### PR DESCRIPTION
The change takes care of the following : 

Earlier:
When the socket gets disconnected due to any network glitch or any of the 2 services (graphite or the service sending metrics) going down temporarily, it never used to try connecting again unless the service sending the metrics was restarted. This could be really expensive as due to a small network glitch, the service needed to be restarted.

Fix:

Two new configurable parameters introduced (README.md) changed to configure the interval at which the socket connection needs to be retried and the number of times it needs to be retried.

The socket connection is retried in case of a write failure/SocketConnectException.

Please review the changes and let me know in case of any suggestions/comments.
